### PR TITLE
Fixed addItem

### DIFF
--- a/src/components/AddListing/AddListingForm/AddListingForm.js
+++ b/src/components/AddListing/AddListingForm/AddListingForm.js
@@ -206,18 +206,23 @@ class AddListingForm extends Component {
             userItems.child(this.props.userId).once('value', snapshot =>{
                 console.log(snapshot.val());
                 items = snapshot.val();
-            });
-            if(items === null){
-                console.log('items is null');
-                items = [];
-                items.push(listing);
-            }else{
-                items.push(listing);
-            }
+            }).then(()=>{
+                if(items === null){
+                    console.log('items is null');
+                    items = [];
+                    items.push(listing);
+                }else{
+                    items.push(listing);
+                }
 
-            userItems.child(this.props.userId+'/').set(items).then(response => {
+                userItems.child(this.props.userId+'/').set(items).then(response => {
+                    this.resetValues();
+                    console.log('listing sent adllisting userID', this.props.userId);
+                    this.props.closeModal();
+                });
+                //just in case it fucks up
+
                 this.resetValues();
-                console.log('listing sent adllisting userID', this.props.userId);
                 this.props.closeModal();
             });
             //


### PR DESCRIPTION
Fixed add Item functionality in addlistingform, not nesting the null checking in a promise after getting the server side items was resulting in the userItems array of items getting nuked due to message asynchrony( or so I suspect but it works now)