### PR TITLE
Bug Fix: account persistance. Home tiles DB grab. Signup DB changes

### DIFF
--- a/src/components/Login/SignUp/CreateAccount/CreateAccount.js
+++ b/src/components/Login/SignUp/CreateAccount/CreateAccount.js
@@ -16,7 +16,10 @@ class CreateAccount extends React.Component {
   }
 
   createUser(email, user, pass, zip){
-    firebase.database().ref('userInfo/' + user).set({
+    var strippedemail = email.replace(/\W/g, '');
+    console.log(strippedemail);
+    firebase.database().ref('userInfo/' + strippedemail).set({
+      username: user,
       email: email,
       password: pass,
       zipcode: zip

--- a/src/containers/Home/Home.js
+++ b/src/containers/Home/Home.js
@@ -41,14 +41,29 @@ class Home extends Component {
 
     componentDidMount () {
         // let userItems = firebase.database().ref('/userItems');
+        var maxListings = 6; //can be modified later.
         this.setState({currentUser: this.props.userId});
-        firebase.database().ref('/userItems').child(this.state.currentUser).on('value', snapshot =>{
-            const items = snapshot.val();
+        var that = this;
+        var fetchedItems = [];
+        var itemType = 'auction'; //can be modified later
+
+        firebase.database().ref('/itemDb').orderByChild('ItemType').equalTo(itemType).limitToLast(maxListings).on('value', snapshot =>{
+          snapshot.forEach(function(childNodes){
+            //only check for public items
+            if (childNodes.val().public === true){
+              fetchedItems.push(childNodes.val());
+            }
+          });
+          console.log(fetchedItems);
+          if(fetchedItems !== null || fetchedItems !== []){
+            that.setState({listing: fetchedItems});
+          }
+            /*const items = snapshot.val();
             console.log(items);
             if(items != null){
                 this.setState({inventory: items});
                 this.setState({listing: items});
-            }
+            } */
 
         });
     }

--- a/src/containers/Home/Home.js
+++ b/src/containers/Home/Home.js
@@ -117,22 +117,27 @@ class Home extends Component {
       //var count = 0;
       const maxListings = 6; // can be dynamic later
       var fetchedItems = [];
+      var itemType = 'auction'; //can be modified later
 
         var that = this;
         firebase.database().ref("/itemDb").orderByChild('location').equalTo(zc).limitToLast(maxListings).on("value", function(snapshot) {
           snapshot.forEach(function(childNodes) {
-            fetchedItems.push( childNodes.val());
+            if(childNodes.val().ItemType === 'auction' && childNodes.val().public === true){
+              fetchedItems.push( childNodes.val());
+            }
           });
             that.setState({listing: fetchedItems});
         });
 
         var that = this;
         if(zc === ""){ //if no filter, want to still show listings
-          firebase.database().ref("/itemDb").limitToLast(maxListings).on('value', function(snap){
+          firebase.database().ref("/itemDb").orderByChild('ItemType').equalTo(itemType).limitToLast(maxListings).on('value', function(snap){
              snap.forEach(function(childNodes){
-               fetchedItems.push(childNodes.val());
+               if (childNodes.val().public === true){
+                 fetchedItems.push(childNodes.val());
+               }
              });
-             if(fetchedItems !== null || fetchedItems !== []){
+             if(fetchedItems !== null || fetchedItems !== [] || fetchedItems !== undefined){
                that.setState({listing: fetchedItems});
              }
           });
@@ -144,10 +149,14 @@ class Home extends Component {
       var maxListings = 6; // can be dynamic later
       var fetchedItems = [];
       var that = this;
-      if (category === 'Select a Category' && this.state.listings === []){
-        firebase.database().ref("/itemDb").limitToLast(maxListings).on('value', function(snap){
+      var itemType = 'auction'; //can be modified later
+      if (category === 'Select a Category' && this.state.listings === undefined){
+        firebase.database().ref("/itemDb").orderByChild('ItemType').equalTo(itemType).limitToLast(maxListings).on('value', function(snap){
           snap.forEach(function(childNodes){
+            //only check for public items
+            if (childNodes.val().public === true){
               fetchedItems.push(childNodes.val());
+            }
           });
           that.setState({listing: fetchedItems});
         });
@@ -155,7 +164,9 @@ class Home extends Component {
       if(category !== 'Select a Category'){
         firebase.database().ref("/itemDb").orderByChild('category').equalTo(category).limitToLast(maxListings).on("value", function(snapshot) {
           snapshot.forEach(function(childNodes) {
-              fetchedItems.push( childNodes.val());
+              if(childNodes.val().public === true && childNodes.val().ItemType === 'auction'){
+                fetchedItems.push( childNodes.val());
+              }
           });
           that.setState({listing: fetchedItems});
         });

--- a/src/store/reducer.js
+++ b/src/store/reducer.js
@@ -1,5 +1,38 @@
+
+function checkLocalStorage() {
+    if((localStorage.getItem("logged") === null) || (localStorage.getItem("logged") === "")){
+        return false;
+    } else {
+        return true;
+    }
+}
+
+function grabAcc(){
+    var user;
+    if(checkLocalStorage()){
+        //todolist = getCookie();
+        user = localStorage.getItem("logged");
+        console.log(user);
+
+    } else {
+      localStorage.setItem("logged",'none');
+    }
+    console.log("grab acc");
+    console.log(user);
+    return user;
+}
+
+//currently id passed to save login is email stripped of info
+//THIS MAY BE THE WRONG USERID!!!
+function saveLogged(id){
+  console.log('id');
+  console.log(id);
+  localStorage.setItem("logged",id);
+}
+
+
 const initialState = {
-    userId: 'none',
+    userId: grabAcc(),
     testField: 'empty'
 }
 
@@ -7,11 +40,14 @@ const reducer = (state = initialState, action) =>{
     switch (action.type) {
         case 'LOGIN':
             console.log("setting userId to:", action.val);
+            localStorage.setItem("logged",action.val); //currently email stripped
+            //localStorage.setItem("logged",action);
             return {
                 userId: action.val};
             break;
 
         case 'LOGOUT':
+            saveLogged('none');
             return {
                 userId: 'none'
             }
@@ -19,7 +55,7 @@ const reducer = (state = initialState, action) =>{
 
     }
         if(action.type === 'login'){
-            console.log('Login action detected')
+            console.log('Login action detected');
             return {
                 userId: action.userId
             }


### PR DESCRIPTION
+ Made account stay logged in even when pages are refreshed.
+ Currently it stores / grabs userid from localstorage. only changes on login/out
+ CURRENTLY USERID is email stripped of @ and .  - symbols ...if this is wrong let me know, i'll try and fix (I think the correct userID is just the username?) - but that's not what is happening currently.



+ Fixed hometiles to show be grabbed from /itemDb
+ only grab auction items..sorted currently by posted date.
+ only grab auction items that are set to public
+ Fixed category and zipcode filter based on new auction type and public settings


+modified signup to save username in db as well and make main file as stripped email.


- CURRENTLY CATEGORY ISN'T WORKING - This is due to the category being the icon names now, which is not consistent with previous version. needs fixing.